### PR TITLE
fix(web): #398 Deleting a factory no longer displays false corruption error messages

### DIFF
--- a/web/src/pages/changelog.vue
+++ b/web/src/pages/changelog.vue
@@ -46,6 +46,7 @@
           <li>It is no longer possible to enter more than .001 of precision into an item's quantity field, as the game doesn't operate any lower than that. Fixed a few rounding error bugs in the process. <a href="https://github.com/satisfactory-factories/application/issues/54>">GH Issue</a></li>
           <li>Items that cannot be produced by any recipe e.g. Leaves are no longer selectable as products. Hand-collected items (Leaves, Wood, Mycelia, alien remains, power slugs, SAM etc.) remain available as raw imports and biomass burner fuel. <a href="https://github.com/satisfactory-factories/application/issues/390">GH Issue</a></li>
           <li>Items that have no recipe for production in buildings are no longer selectable (e.g. Leaves). <a href="https://github.com/satisfactory-factories/application/issues/390>">GH issue</a></li>
+          <li>Deleting a factory that imported from other factories no longer displays false "corrupted data" error messages for those factories. <a href="https://github.com/satisfactory-factories/application/issues/398">GH Issue</a></li>
         </ul>
 
         <v-divider />

--- a/web/src/utils/factory-management/dependencies.spec.ts
+++ b/web/src/utils/factory-management/dependencies.spec.ts
@@ -10,6 +10,7 @@ import { addInputToFactory, getInput } from '@/utils/factory-management/inputs'
 import { gameData } from '@/utils/gameData'
 import { addProductToFactory } from '@/utils/factory-management/products'
 import { create251Scenario } from '@/utils/factory-setups/251-multiple-imports'
+import { complexDemoPlan } from '@/utils/factory-setups/complex-demo-plan'
 
 describe('dependencies', () => {
   let factories: Factory[] = []
@@ -299,6 +300,33 @@ describe('dependencies', () => {
 
       // And also check if the input has been filtered from the dependant
       expect(mockDependantFactory.inputs.length).toBe(0)
+    })
+
+    // GH: #398
+    it('should remove requests held by provider factories so deletion does not trigger corruption alerts', () => {
+      const factories = complexDemoPlan().getFactories()
+      calculateFactories(factories, gameData)
+
+      // Circuit Boards imports from other factories (e.g. Oil Processing, Copper Basics), so those providers
+      // hold dependency requests keyed by the Circuit Boards factory ID.
+      const factory = findFacByName('Circuit Boards', factories)
+      const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+      // Mimic Planner.vue deleteFactory()
+      const index = factories.findIndex(fac => fac.id === factory.id)
+      removeFactoryDependants(factory, factories)
+      factories.splice(index, 1)
+      calculateFactories(factories, gameData)
+
+      // No factory should still hold requests keyed by the deleted factory's ID
+      factories.forEach(fac => {
+        expect(fac.dependencies.requests[factory.id]).toBe(undefined)
+      })
+
+      // And the user should not have been told their data is corrupted
+      expect(alertMock).not.toHaveBeenCalled()
+
+      alertMock.mockRestore()
     })
   })
 

--- a/web/src/utils/factory-management/dependencies.ts
+++ b/web/src/utils/factory-management/dependencies.ts
@@ -120,9 +120,17 @@ export const removeFactoryDependants = (factory: Factory, factories: Factory[]) 
 
       // Remove the dependency from the calling factory
       // Not that this massively matters as the factory is likely getting deleted
-      delete factory.dependencies.requests[factory.id]
+      delete factory.dependencies.requests[dependentId]
     })
   }
+
+  // Remove any requests that other factories (e.g. the factory's providers) hold against this factory.
+  // If left behind, flushInvalidRequests would falsely flag those factories as corrupted after deletion. GH: #398
+  factories.forEach(otherFac => {
+    if (otherFac.dependencies?.requests?.[factory.id]) {
+      delete otherFac.dependencies.requests[factory.id]
+    }
+  })
 }
 
 // Loop through all factories, checking their inputs and building a dependency tree.


### PR DESCRIPTION
When a factory was deleted, removeFactoryDependants only cleaned up one direction of the dependency graph: inputs on factories that imported FROM the deleted factory. Factories the deleted factory imported from (its providers) still held dependencies.requests entries keyed by the deleted factory's ID. The subsequent recalculation ran flushInvalidRequests, which found requests pointing at a now-nonexistent factory and alerted "corrupted data" once per affected provider factory.

removeFactoryDependants now also removes the deleted factory's requests from all remaining factories, so a normal deletion cannot trip the corruption alert (which remains in place for genuinely corrupt saves). Also fixes an adjacent bug where the dependant loop deleted requests[factory.id] instead of requests[dependentId].