### PR TITLE
chore(repo): Name the Docker job for what the run actually does

### DIFF
--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -16,8 +16,11 @@ on:
         default: false
 
 jobs:
+  # Both names key off `push` so a run says what it actually did. A validation
+  # build that announces itself as "Build and push" reads as though it published
+  # an image, which is exactly the confusion this avoids.
   build:
-    name: Build API image
+    name: ${{ inputs.push && 'Build & push API image' || 'Build API image' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -34,7 +37,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      # buildx builds and pushes in a single invocation — layers stream straight
+      # to the registry. Splitting this into a build step and a `docker push`
+      # step would mean loading the image into the local daemon first, which is
+      # slower and buys nothing, so the split is in the naming not the mechanism.
+      - name: ${{ inputs.push && 'Build and push' || 'Build' }}
         uses: docker/build-push-action@v6
         with:
           # The repo root, not backend/ — backend/package.json's `catalog:`


### PR DESCRIPTION
Same change I just made in `albionroads` — this repo has the identical pattern in `publish-backend.yml`.

The reusable backend image workflow always announced its build step as **"Build and push"**, including on pull requests, where it builds the image and never touches the registry. That reads as though every PR publishes an image. It does not.

Both the job name and the build step name now key off the `push` input:

| Run | Job name | Step name |
|---|---|---|
| Pull request (`push: false`, via `pr-docker-backend.yml`) | `Build API image` | `Build` |
| Deploy to `main` (`push: true`, via `deploy-backend.yml`) | `Build & push API image` | `Build and push` |

## Why the build and push are still one step

I considered splitting them into a build step and a separate `docker push`. Not doing it: `docker/build-push-action` runs buildx once and streams layers straight to the registry. Splitting would mean materialising the image into the local daemon with `load: true` and pushing afterwards, which is slower and buys nothing. The label was what was wrong, not the mechanism.

## Validation

No behavioural change — the `push:` input, the `if: inputs.push` gate on the registry login, and the tags are all untouched.

The equivalent change is already verified in `albionroads`: on a PR run there the job rendered as `Build server image` and the step as `Build`, with `Log in to Docker Hub` reporting `skipped`. Worth confirming the same on the checks here, since `inputs` in `jobs.<job_id>.name` is documented but has had community reports of falling back to the job id — it resolved correctly in that test.