### PR TITLE
chore(repo): Add a Renovate config with a 14 day release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "description": [
+    "Renovate has been raising PRs against this repo with no config file committed, so it was running on whatever the hosted app defaults to. This pins the baseline down so the behaviour is in the repo rather than implied.",
+    "A release has to have been public for 14 days before Renovate will propose it. That window is where a compromised or immediately-yanked publish gets found by someone else before it reaches a PR here.",
+    "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below."
+  ],
+  "minimumReleaseAge": "14 days"
+}


### PR DESCRIPTION
Renovate has been raising PRs against this repo with **no config file committed** — #442 (vuetify) landed that way, and there is no onboarding PR and no Dependency Dashboard. It has been running on whatever the hosted app defaults to. This pins the baseline down so the behaviour lives in the repo rather than being implied.

A release now has to have been public for 14 days before Renovate proposes it — the window in which a compromised or immediately-yanked publish gets caught by someone else first.

## Security fixes are not delayed

Renovate's built-in `vulnerabilityAlerts` defaults are `minimumReleaseAge: null`, `schedule: []` and `prCreation: "immediate"`, so a CVE fix is still raised the moment the alert lands. Nothing extra needs configuring for that — restating those defaults would only risk drifting from upstream, so the reasoning is recorded in the `description` block instead.

## Scope

Deliberately minimal: `config:recommended` plus the release age. No automerge rules, no grouping, no workspace-specific packageRules — those are a separate decision and this repo has three packages that each keep their own lockfile, so grouping wants thinking about on its own.

Dependabot is currently doing security-only updates here (no `dependabot.yml`, so no version updates). That is complementary rather than duplicated for now, but once Renovate is configured to handle security updates too, Dependabot security updates should be switched off while leaving Dependabot **alerts** on — Renovate reads those alerts to find CVEs.