### PR TITLE
chore(repo): Set platformAutomerge false ahead of any automerge decision

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,9 @@
   "description": [
     "Renovate has been raising PRs against this repo with no config file committed, so it was running on whatever the hosted app defaults to. This pins the baseline down so the behaviour is in the repo rather than implied.",
     "A release has to have been public for 14 days before Renovate will propose it. That window is where a compromised or immediately-yanked publish gets found by someone else before it reaches a PR here.",
-    "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below."
+    "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below.",
+    "Nothing automerges here yet, so platformAutomerge is set ahead of that decision rather than in response to it. If automerge is ever turned on, Renovate should merge its own PRs: GitHub auto-merge is disabled on this repo, and main has a review requirement with no required status checks behind it, so the platform route would be both blocked and the weaker gate. Renovate waits for the whole branch to go green."
   ],
-  "minimumReleaseAge": "14 days"
+  "minimumReleaseAge": "14 days",
+  "platformAutomerge": false
 }


### PR DESCRIPTION
Sets `platformAutomerge: false` explicitly, for consistency with the other three projects.

Nothing automerges in this repo yet — the config here is age-only — so this lands ahead of that decision rather than in response to it. If automerge is ever enabled, Renovate should be the one merging:

- GitHub auto-merge is disabled at the repo level, so the platform route fails and falls back anyway.
- The `PR approvals` ruleset requires one approving review, which Renovate cannot satisfy itself, so the platform route would be blocked outright.
- Its `required_status_checks` rule carries an **empty** check list, so GitHub auto-merge would gate on nothing. Renovate waits for the whole branch to go green (`ignoreTests` defaults to false).

That empty required-checks list is worth addressing on its own terms — as it stands a red PR can be merged by hand with nothing stopping it. Out of scope here.

**Validation:** config parses as JSON. No behaviour changes today, since no rule enables automerge.