### PR TITLE
chore(repo): Let Renovate merge its own PRs when they are green

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -5,11 +5,15 @@ on:
       - main
     paths:
       - 'web/**'
+  # Deliberately NOT path-filtered, unlike the push trigger above. This job is a
+  # required status check on main, and a required check that never runs sits
+  # pending forever rather than passing — so a path filter here would block every
+  # PR that does not touch web/ (a backend bump, a docs change, a config edit)
+  # with no way to satisfy it. Running the web suite on those PRs costs a couple
+  # of minutes and is the price of it being required.
   pull_request:
     branches:
       - main
-    paths:
-      - 'web/**'
 jobs:
   build-web:
     name: Build & Test Web

--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,20 @@
     "Renovate has been raising PRs against this repo with no config file committed, so it was running on whatever the hosted app defaults to. This pins the baseline down so the behaviour is in the repo rather than implied.",
     "A release has to have been public for 14 days before Renovate will propose it. That window is where a compromised or immediately-yanked publish gets found by someone else before it reaches a PR here.",
     "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below.",
-    "Nothing automerges here yet, so platformAutomerge is set ahead of that decision rather than in response to it. If automerge is ever turned on, Renovate should merge its own PRs: GitHub auto-merge is disabled on this repo, and main has a review requirement with no required status checks behind it, so the platform route would be both blocked and the weaker gate. Renovate waits for the whole branch to go green."
+    "Patch and minor updates merge themselves once the branch is green. Renovate does the merging rather than GitHub's auto-merge: GitHub auto-merge is disabled on this repo, and it waits on required checks alone, where Renovate waits for the whole branch to go green. Majors are left alone deliberately.",
+    "automergeStrategy is pinned to squash because the branch ruleset on main restricts merges to squash only. Left on the default of auto, Renovate picks a strategy from the repo's settings — which still allow merge commits and rebases — and the merge is refused."
   ],
   "minimumReleaseAge": "14 days",
-  "platformAutomerge": false
+  "platformAutomerge": false,
+  "automergeStrategy": "squash",
+  "packageRules": [
+    {
+      "description": "Patch and minor updates merge themselves. Build & Test Web is a required check on main, so nothing lands without that suite passing.",
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Turns on automerge for patch and minor updates, which this repo has never had — its Renovate config was age-only.

The review requirement that made automerge pointless here dates from when other people were pushing to this repo regularly. That is no longer its shape, and an automerge rule that can never fire is worse than not having one: PRs sit looking enabled while nothing lands.

Two supporting changes, both of which would have silently broken it:

**`automergeStrategy: "squash"`.** The ruleset on `main` permits squash merges only, while the repo settings still allow merge commits and rebases. Renovate's default (`auto`) picks a strategy from repo settings, so its merges would have been refused.

**`Web Checks` drops its `pull_request` path filter.** It is now a required check on `main`, and a required check that never runs stays **pending** rather than passing — so filtering it to `web/**` would block every PR that doesn't touch the frontend, with nothing able to satisfy it. This PR is itself an example: it touches no `web/` file. The `push` trigger keeps its filter, since nothing depends on that one reporting.

Majors still wait for a human. `minimumReleaseAge: 14 days` and `platformAutomerge: false` are unchanged.

**Note:** this depends on a ruleset change on `main` that isn't in this diff — dropping the approval requirement to 0 and removing the Renovate bypass actor, so the required check applies to Renovate too rather than being bypassed along with the review.

**Validation:** `renovate.json` parses as JSON, the workflow parses as YAML with both triggers intact. The `Build & Test Web` job name is unchanged, so the required-check context still matches.