### PR TITLE
chore(vercel): Stop preview deployments on bot branches

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,4 +1,10 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "renovate/**": false,
+      "dependabot/**": false
+    }
+  },
   "rewrites": [
     { "source": "/graph", "destination": "/" },
     { "source": "/recipes", "destination": "/" },


### PR DESCRIPTION
Preview deployments on dependency PRs are failing with:

```
Resource is limited - try again in 24 hours (more than 100, code: "api-deployments-free-per-day")
```

The Vercel free plan allows **100 deployments a day across the whole account**, not per project. Every push to an open PR spends one, and with ten or more dependency PRs open — each rebase counting as another push — the cap is reached well before the day is out. On 2026-07-27 Albion Roads alone spent all 100, which is why previews here started failing too.

Once a preview fails, the status is attached to that commit and stays failed until a new deployment runs. Renovate waits for the *whole* branch to be green, not just the required checks, so a rate-limited Vercel run stops dependency PRs merging even when Build Backend, Build Parsing and Build & Test Web are all passing.

## Why turning it off is the right call rather than a workaround

A preview of a dependency bump is not worth a deployment slot. `Build & Test Web` lints, builds and tests the client on every PR, so a bump that breaks the app fails there first — the Vercel build is downstream of the thing that already caught it.

`renovate/**` and `dependabot/**` are excluded via [`git.deploymentEnabled`](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled), which takes minimatch patterns. Human PRs are untouched and still get a preview.

## Validation

`web/vercel.json` parses, and this PR is itself the check: it is not a bot branch, so it **should** still get a Vercel preview. The real confirmation is the next Renovate PR getting no Vercel status at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)