### PR TITLE
chore(repo): automerge pre-1.0 minor bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,17 @@
         "minor"
       ],
       "automerge": true
+    },
+    {
+      "description": [
+        "Below 1.0.0, a bump of the second digit (0.6 -> 0.7) is a major update to Renovate, because ^0.6.0 does not permit 0.7.0 under semver. The patch/minor rule above therefore never matches pre-1.0 packages, and they were being left for manual merge.",
+        "This treats those the same as any other minor: merged once the branch is green. Genuine 1.0+ majors still require a human."
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchCurrentVersion": "<1.0.0",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a second `packageRules` entry so that dependency updates below `1.0.0` automerge on a green branch, the same as any other minor.

```json
{
  "matchUpdateTypes": ["major"],
  "matchCurrentVersion": "<1.0.0",
  "automerge": true
}
```

## Why

The existing patch/minor automerge rule looked like it should already cover these, but it never matched them. Below `1.0.0`, Renovate classifies a bump of the second digit (`0.6` → `0.7`) as a **major** update, because `^0.6.0` does not permit `0.7.0` under semver — pre-1.0, that digit is the breaking-change slot.

The tell is the branch naming: #457 ("update dependency iconv-lite to `^0.7.0`") was raised on `renovate/iconv-lite-0.x`, which is the major branch pattern. So `matchUpdateTypes: ["patch", "minor"]` could never apply to pre-1.0 packages, and they were piling up waiting on a manual merge.

This is a deliberate loosening rather than a bug fix — pre-1.0 packages are entitled to break on that digit, and CI is the only gate on it. The trade seems right here given the test coverage the suites give us, and the packages it actually affects are dev-side (`iconv-lite`, `neostandard` and similar).

Majors at `1.0.0` and above are unchanged and still need a human.

## Validation

Checked against Renovate's own schema validator rather than by eye:

```
$ pnpm dlx --package renovate renovate-config-validator renovate.json
 INFO: Validating renovate.json as global config
 INFO: Config validated successfully against 1 file(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)