### PR TITLE
fix(ci): Call the deploy hook with curl instead of a marketplace action

### DIFF
--- a/.github/workflows/deploy-webhook.yml
+++ b/.github/workflows/deploy-webhook.yml
@@ -1,7 +1,7 @@
 name: "Backend: Trigger Deployment Webhook"
 
 # Reusable, and deliberately the last link in the chain. Pokes the webhooks
-# server, which SSHes to the API box and runs /root/update.sh there.
+# server, which SSHes to the API box and redeploys it there.
 #
 #   POST <WEBHOOK_URL>   — the deploy hook on the webhooks host
 #
@@ -21,20 +21,29 @@ jobs:
   send-webhook:
     name: Trigger deployment
     runs-on: ubuntu-latest
+    # Backstop only. --max-time below should resolve first.
+    timeout-minutes: 5
     steps:
+      # curl rather than an action. Every Actions wrapper for this leaves Node's
+      # default agent in place, and since Node 19 https.globalAgent carries
+      # timeout: 5000 — so the socket is killed at 5s no matter what timeout the
+      # action was given, and the error still quotes the configured value. The
+      # hook waits for the whole deploy, so that fired on every single run.
       - name: Trigger webhook
-        uses: ramzzisudip/secure-github-webhook@0.3.0
-        with:
-          url: "${{ secrets.WEBHOOK_URL }}"
-          data: '{ "application": "satisfactory-factories" }'
-          timeout: 2000
-          hmacSecret: "${{ secrets.WEBHOOK_SECRET }}"
-
-      # A green tick here means the webhook server accepted the request, NOT
-      # that the deploy worked: the hook returns 200 without waiting for the
-      # SSH, so a failed deploy still looks successful in Actions. The real
-      # confirmation is /root/deploy.log on the API box.
-      - name: What green means here
+        env:
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         run: |
-          echo "Webhook accepted. This does NOT confirm the deploy succeeded."
-          echo "Confirm on the box: ssh sf 'tail -5 /root/deploy.log'"
+          body='{"application":"satisfactory-factories"}'
+          signature=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -r | cut -d' ' -f1)
+
+          # The hook answers 200 or 500 carrying the deploy's own output, so this
+          # step's result is the deploy's result — green here now does mean deployed.
+          # 180s clears the ~100s at which the proxy in front gives up and returns a
+          # 524, which at least says the deploy was still running.
+          curl --fail-with-body --silent --show-error --max-time 180 \
+            --header 'Content-Type: application/json' \
+            --header "X-Hub-Signature-256: sha256=$signature" \
+            --header "X-Hub-SHA: $GITHUB_SHA" \
+            --data "$body" \
+            "$WEBHOOK_URL"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,16 +39,17 @@ still there as a break-glass path and says so at the top.
 
 ## Things that surprise you later
 
-- **A green Actions run does not mean the deploy worked.** The webhook returns
-  `200` as soon as it accepts the request — it does not wait for the SSH, and it
-  does not report the script's exit code. The only honest confirmation is
-  `/root/deploy.log` on the box.
+- **A green Actions run means the deploy worked.** Since 2026-07-28 the hook waits
+  for the deploy and answers `200` or `500` carrying the script's own output, so the
+  Deploy step's result *is* the deploy's result. It did not always — it used to answer
+  `200` the moment it accepted the request, which is what the older advice further
+  down is written against. `/root/deploy.log` is still where the reason lives.
 - **A wrong `WEBHOOK_SECRET` does *not* fail silently.** Verified against
   `webhook` 2.8.2 on 2026-07-27: a signature computed with the wrong secret
   returns `500` (`invalid payload signatures`) and fails the Deploy step. `404`
   means the hook isn't loaded. `403` means no signature header was sent at all.
-  Only `200` is ambiguous — and it is ambiguous in exactly one direction: the
-  command ran, but nothing reports whether it *worked*.
+  `200` now means the script ran *and* exited `0`, with its output in the response
+  body — it used to mean only that the request was accepted.
 - **The image builds from the repo root, not from `backend/`.**
   `backend/package.json` pins `ts-node`, `typescript` and the eslint packages
   with `catalog:`, and a catalog only resolves when pnpm can see
@@ -250,10 +251,10 @@ again, so a local retag is a stopgap, not a state anyone else can see.
 
 | Symptom | Likely cause |
 | --- | --- |
-| Actions green, nothing changed on the box | Three different causes, and **the webhook returns `200` for all of them**: a wrong `WEBHOOK_SECRET`, a failed SSH, or a no-op pull. Work down `/root/deploy.log` on `sf` first — if it has no new entry at all, the hook never ran the script, so suspect the secret. Then `app/config/logs/webhooks.log` on the webhooks box |
+| Actions green, nothing changed on the box | Almost always a genuine no-op pull — `deploy.log` will say `Image unchanged`. A wrong `WEBHOOK_SECRET` and a failed SSH both fail the Deploy step now rather than hiding behind a `200` |
 | `Image unchanged` in `deploy.log` after a real change | The box's `/root/docker/docker-compose.yml` still pulls the old `ghcr.io/...` tag. It is not version-controlled — edit it there |
 | Deploy step fails with `500` | `WEBHOOK_SECRET` here does not match `webhook.env` on the webhooks box. The daemon logs `error evaluating hook: invalid payload signatures` |
-| **Deploy step green but no entry in `deploy.log`** | The hook ran `deploy.sh` but the SSH failed — `200` is returned before the SSH result is known. Check `app/config/logs/webhooks.log` on the webhooks box: `docker compose -f /root/webhooks/docker-compose.yml logs webhook` |
+| **Deploy step green but no entry in `deploy.log`** | Routine before 2026-07-28, when `200` came back before the SSH result was known. It should not happen now — if it does, check `app/config/logs/webhooks.log` on the webhooks box: `docker compose -f /root/webhooks/docker-compose.yml logs webhook` |
 | `404` from the webhook step | The `satisfactory-factories` hook is not loaded. On the webhooks box: `cd /root/webhooks && ./sync.sh` and check the hook list it prints. `404` is the *only* HTTP status that reliably tells you something is wrong |
 | `DEPLOY FAILED` in `deploy.log` after `up --wait` | The new image starts but never turns healthy. `ssh sf 'docker logs sf-backend'` — most likely a bad `sf.env` or Mongo unreachable |
 | Publish step fails on `pnpm install --frozen-lockfile` | `backend/pnpm-lock.yaml` is out of date with `backend/package.json`. Run `pnpm install` in `backend/` and commit the lockfile |

--- a/docs/how-do-we-release.md
+++ b/docs/how-do-we-release.md
@@ -30,7 +30,7 @@ When a PR touching `backend/` (or the workspace files the image is built from) i
 
 This used to be a manual `backend/publish.sh` run from a laptop, which meant only one person could ship the API at all. That script still exists as a break-glass path for when GitHub Actions is unavailable, and says so at the top.
 
-**A green Actions run is not proof the deploy landed** — the webhook returns `200` before the SSH even happens. The confirmation is `/root/deploy.log` on the box.
+**A green Actions run now means the deploy landed** — since 2026-07-28 the hook waits for the deploy and answers `200` or `500` carrying the script's own output, and the Deploy step fails on the `500`. It used to answer `200` on acceptance alone. `/root/deploy.log` on the box is still where the reason for a failure lives.
 
 Two files on the server — its compose file and its `update.sh` — are mirrored in `backend/` but are *not* synced by any deploy; they have to be copied over by hand when they change.
 


### PR DESCRIPTION
## The problem

`ramzzisudip/secure-github-webhook@0.3.0` never sets its own HTTP agent, so it inherits Node's default. Since Node 19 `https.globalAgent` is `{keepAlive: true, timeout: 5000, …}`, and that `timeout` is a socket idle timeout. While the hook is busy deploying the socket is idle, so it fires at 5s, the request emits `timeout`, and axios rejects using its *configured* message — which is why the error quotes a duration that never elapsed.

The `timeout` input is unreachable for anything over 5 seconds. This one is set to `2000`, so it has never had a chance either way.

It did not matter while the hook answered immediately. It became synchronous on 2026-07-28 — it now waits for the whole deploy and answers with its outcome — and the last backend deploy took `21.1s`, well past the ceiling. I found this on diglet-bot, which shares the same hooks and has failed on every single run since that day.

Reproduced with no involvement from our own infrastructure, running the action's own `dist/index.js` against `https://httpbin.org/delay/10`:

```
::error::Error: timeout of 120000ms exceeded
EXIT after 5373ms
```

The same request with a fresh agent returns `OK 200 after 11273ms`.

## The change

`openssl dgst -sha256 -hmac` for the signature, `curl` for the request. `--fail-with-body` is what makes this step meaningful — the hook answers `200` or `500` carrying the deploy script's own output, so a red run is now a real deploy failure with the reason attached. `--max-time 180` clears the ~100s at which the proxy in front gives up and returns its own `524`.

Because green now genuinely means deployed, the `What green means here` step is gone, and the docs that told you not to trust it are corrected:

- `docs/how-do-we-release.md` and `docs/deployment.md` — the two headline "a green run is not proof" claims.
- The `WEBHOOK_SECRET` bullet, which said `200` was ambiguous. It is not any more.
- Two troubleshooting rows written against the old fire-and-forget behaviour.

The same change is going into the other three repos that call these hooks, and the canonical snippet is documented in the webhooks repo.

## Validation

- The `openssl` digest is byte-identical to the action's node HMAC over the same body.
- `500` → step fails with the body printed. `200` → passes. **10-second delayed response → passes**, which is the case that was failing.
- The workflow file parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)