### PR TITLE
fix(web): stop VImg size polls outliving the jsdom teardown

### DIFF
--- a/web/src/setup-vitest.ts
+++ b/web/src/setup-vitest.ts
@@ -68,6 +68,15 @@ if (typeof globalThis.visualViewport === 'undefined') {
   }
 }
 
+// jsdom never loads images, so an <img> stays `complete: false` with a zero natural
+// size forever — and Vuetify's VImg keeps re-arming its 100ms size poll to wait for
+// one. Nothing unmounts those components, so the timers outlive the jsdom teardown
+// between test files and throw `window is not defined`, which Vitest counts as an
+// unhandled error and exits 1 on. Report a size so the poll settles on its first tick.
+for (const prop of ['naturalWidth', 'naturalHeight'] as const) {
+  Object.defineProperty(HTMLImageElement.prototype, prop, { configurable: true, get: () => 1 })
+}
+
 let gameData: any = null
 let gameDataVersion: string | null = null
 


### PR DESCRIPTION
## The problem

The web test job goes red at random with **every test passing**. The most recent example is #497 — a README-only change — whose run reported:

```
Test Files  65 passed (65)
    Errors  45 errors
```

All 45 are the same unhandled error, attributed to `Product.spec.ts`:

```
ReferenceError: window is not defined
 ❯ Timeout.poll vuetify/src/components/VImg/VImg.tsx:260:11
```

Vitest sets a non-zero exit code whenever unhandled errors exist, so the job fails even though nothing is actually broken:

```js
_checkUnhandledErrors(errors) {
  if (errors.length && !this.config.dangerouslyIgnoreUnhandledErrors) process.exitCode = 1;
}
```

## Cause

`VImg` polls the `<img>` element for its natural size, re-arming every 100ms while it believes the image is still loading:

```js
} else if (!img.complete && state.value === 'loading' && timeout != null) {
  timer = window.setTimeout(poll, timeout);   // the throw site
}
```

In jsdom an `<img>` with a `src` never resolves — `complete: false`, `naturalWidth: 0`, `currentSrc: ""`, permanently. So that branch is unreachable-from and the poll re-arms forever. The timer is only cleared in `onBeforeUnmount`, and no component spec unmounts its wrapper.

`Product.vue` renders a `GameAssetContent` (a `v-img`) per item and building, and `Product.spec.ts` mounts the component eight times across five tests, which is where the ~45 live pollers come from. Measured with a throwaway probe: **a single `VImg` schedules 7 polls in 550ms and leaves a live timer at the end of the test**.

The throw itself needs a tick to land after Vitest destroys the jsdom environment but while the forked worker is still alive for the next file — which is why it shows up on CI's slower runners and is hard to reproduce on a fast local machine. Deterministic cause, timing-dependent symptom.

## Fix

Report a natural size in the test environment so the poll settles on its first tick and never re-arms. Nine lines in `setup-vitest.ts`, next to the existing jsdom polyfills.

Both components that use `v-img` under test (`GameAssetContent`, `Splash`) already pin an aspect ratio and explicit dimensions, so a reported 1×1 changes nothing they render.

## Validation

- The probe goes from 7 polls / 1 live timer to **0 polls / 0 live timers** with the stub coming from the setup file alone.
- Full web suite: 69 files, 1259 passed / 1 skipped, no unhandled errors, exit 0 — repeated to confirm it stays clean.
- `pnpm lint-check` clean.

Considered and rejected: `dangerouslyIgnoreUnhandledErrors`, which would hide genuine unhandled errors too. A follow-up worth doing separately is `enableAutoUnmount(afterEach)`, which would stop *any* component leaking timers past teardown rather than just this one — it changes wrapper lifetimes across all 69 spec files, so it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)