### PR TITLE
feat(backend): add a health check that actually proves Mongo is alive

### DIFF
--- a/.claude/memory/backend-deploy-and-prod-drift.md
+++ b/.claude/memory/backend-deploy-and-prod-drift.md
@@ -1,8 +1,11 @@
 ---
 name: backend-deploy-and-prod-drift
-description: Production runs a 19-month-old API image that main can no longer rebuild — the deploy automation and its three prerequisite fixes are in PR #439, not yet merged or exercised
-metadata:
+description: "Production runs a 19-month-old API image that main can no longer rebuild — the deploy automation and its three prerequisite fixes are in PR #439, not yet merged or exercised"
+metadata: 
+  node_type: memory
   type: project
+  originSessionId: c8f2ec29-4279-445c-a3ea-4132f13d5e7f
+  modified: 2026-08-01T14:03:26.448Z
 ---
 
 As of **2026-07-27**, the live API on the `sf` box runs an image built ~19 months ago.
@@ -33,6 +36,12 @@ running on the box, and each one individually looks like it works. Anyone who as
 API is deployable from `main` today, or reads a green Actions run as proof, will reach the
 wrong conclusion. The pattern to remember beyond these three: **on this project, the deploy
 path has no test coverage, so its breakages accumulate silently until someone needs to ship.**
+
+**Open drift as of 2026-08-01:** the repo's `docker-compose-server.yml` now probes `/health`
+(which pings Mongo and 503s), but the box's copy still probes `/hello`. Until it is copied
+across by hand, the container's health state still only proves the process is up — and once
+it *is* copied, `(healthy)` starts meaning "Mongo answered too", so a deploy attempted during
+a database outage will fail at `up -d --wait` rather than going green. That is intended.
 
 **How to apply:** `docs/deployment.md` (added by #439) is the authoritative description of
 the chain once merged — read it rather than re-deriving. Verify a deploy on the box

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file. It mirrors the 
 
 ## [Unreleased]
 
+### Backend — a health check that can actually fail
+
+- The API had one health route, `GET /hello`, and it returned `200` for as long as the Node process was alive. It never spoke to Mongo, so the database could be dead, unreachable or out of disk and the monitoring would still show green — which is exactly what happened when the API box filled its disk. New `GET /health` runs a real `ping` against Mongo (the `SELECT 1` equivalent) and returns **503** with the error message when it doesn't answer, so an outage raises an alert instead of nothing. The response also carries process uptime, the Mongoose connection state and how long the ping took.
+- The ping is raced against a 3 second timeout. Mongoose is configured with `bufferCommands`, so with the database down a command doesn't fail — it queues for ten seconds, which is longer than any monitor or the Docker healthcheck will wait, and a dead database would have looked like a slow one.
+- `/health` gets its own rate limit of 10 requests a minute and is exempt from the global limiter, so no amount of other traffic can push a monitor into a `429` and a false outage.
+- The production container's Docker healthcheck now probes `/health` rather than `/hello`, so `docker ps` reports unhealthy when Mongo dies rather than only when the process does. Consequence: a deploy attempted while Mongo is down now fails at `up -d --wait` instead of going green. **The box's compose file is a hand-maintained mirror and no deploy syncs it** — see `docs/deployment.md`.
+- `/hello` stays as-is, as a pure liveness route.
+
 ### Sidebar — Active factory indicator
 
 - The sidebar's factory list now shows which factory you're currently looking at: an orange bar (the same orange as the selected tab's underline) on the left edge of that factory's entry, following you as you scroll the plan or jump between factories — no more losing your place in a 30-factory plan. A factory counts as "in view" when its card spans an eye-line 10% down the planner pane (not the pane's very top edge), so a factory scrolled slightly past its header is still credited as the one being viewed rather than the tail end of the factory above it. The Statistics and Factories Summary jump-links get the same treatment when their sections are in view, and while the eye-line crosses the divider gap between two cards the indicator stays put on the last entry instead of blinking off. Works in both the desktop sidebar and the mobile navigation drawer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ This is the core of the app. Everything else is UI around it.
 
 ### Backend (`backend/backend.ts`)
 
-Single-file Express app. Routes: `/register`, `/login`, `/validate-token` (JWT), `/save` + `/load` (authenticated plan sync), `/share` + `/share/:id` (shareable plans, rate-limited). Mongoose models in `backend/models/`. API base URL is selected in `web/src/config/config.ts` by `VITE_ENV`.
+Single-file Express app. Routes: `/register`, `/login`, `/validate-token` (JWT), `/save` + `/load` (authenticated plan sync), `/share` + `/share/:id` (shareable plans, rate-limited), `/hello` (liveness) and `/health` (liveness + a Mongo ping, 503 when the database is unreachable — this is what uptime monitoring points at). Mongoose models in `backend/models/`. API base URL is selected in `web/src/config/config.ts` by `VITE_ENV`.
 
 ### Game data versioning (important, easy to get wrong)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,7 +49,8 @@ To tear the container back down, `pnpm db:down` from either the root or here.
 | `POST /validate-token` | Token check |
 | `POST /save`, `GET /load` | Authenticated plan sync |
 | `POST /share`, `GET /share/:id` | Shareable plans, separately rate-limited |
-| `GET /hello` | Health check |
+| `GET /hello` | Liveness only — 200 whenever the process is up. It never touches Mongo, so don't monitor it |
+| `GET /health` | The one to monitor. Pings Mongo and returns **503** if it doesn't answer inside 3s. Rate limited to 10 requests a minute, in its own bucket |
 
 Mongoose models are in `models/`.
 

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -29,6 +29,10 @@ dotenv.config();
 // out of each other's way locally. Nothing deployed sets it.
 const PORT = Number(process.env.PORT) || 3001;
 
+// How long /health waits on Mongo before calling it dead. Well under the 5s
+// Docker healthcheck timeout, and under any monitor's default.
+const DB_PING_TIMEOUT_MS = 3000;
+
 // *************************************************
 // Setup Express
 // *************************************************
@@ -36,12 +40,22 @@ const PORT = Number(process.env.PORT) || 3001;
 // Configure rate limiter: maximum of 200 requests per 5 minutes (40 a minute)
 const apiRateLimit = rateLimit({
   windowMs: 5 * 60 * 1000, // 5 minutes
-  max: 200
+  max: 200,
+  // /health has its own limiter below; exempting it here keeps it in one bucket
+  // rather than two, so other traffic can never rate-limit the monitor into
+  // reporting a false outage.
+  skip: (req) => req.path === '/health'
 });
 // Prevent people / bots from spamming the crap out of the button to 1 share a minute
 const shareRateLimit = rateLimit({
   windowMs: 5 * 60 * 1000, // 5 minutes
   max: 5
+});
+// updown.io probes from three sources and Docker probes every 30s, each on its
+// own IP bucket, so 10 a minute is generous.
+const healthRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10
 });
 
 const app: Express.Application = Express();
@@ -123,9 +137,48 @@ const optionalAuthenticate = (req: AuthenticatedRequest, res: Express.Response, 
 // Routes
 // *************************************************
 
-// Hello Endpoint
+// Hello Endpoint. Liveness only — it proves the process is up and nothing else.
+// Monitoring belongs on /health.
 app.get('/hello', function (_req: Express.Request, res: Express.Response) {
   res.status(200).json({ message: 'Hello, the server is running!' });
+});
+
+// Health Endpoint. 200 only if Mongo answers, 503 otherwise, so uptime
+// monitoring sees a database outage instead of a cheerful process.
+app.get('/health', healthRateLimit, async (_req: Express.Request, res: Express.Response) => {
+  const startedAt = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  let error: string | undefined;
+
+  try {
+    const db = mongoose.connection.db;
+    if (!db) throw new Error('No database handle');
+    // ping is Mongo's SELECT 1. Raced because bufferCommands queues the command
+    // for 10s when the connection is down — longer than any monitor will wait,
+    // which would make a dead database look like a slow one.
+    await Promise.race([
+      db.admin().command({ ping: 1 }),
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out after ${DB_PING_TIMEOUT_MS}ms`)), DB_PING_TIMEOUT_MS);
+      })
+    ]);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+    console.error(`Health check failed: ${error}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  res.status(error ? 503 : 200).json({
+    status: error ? 'fail' : 'ok',
+    uptime: Math.round(process.uptime()),
+    database: {
+      status: error ? 'fail' : 'ok',
+      state: mongoose.STATES[mongoose.connection.readyState],
+      responseTime: Date.now() - startedAt,
+      ...(error ? { error } : {})
+    }
+  });
 });
 
 // Register Endpoint

--- a/backend/docker-compose-server.yml
+++ b/backend/docker-compose-server.yml
@@ -24,11 +24,15 @@ services:
       - "3001:3001"
     command: pnpm start
     healthcheck:
-      # /hello is the API's own liveness route. node 24 ships global fetch, so
-      # this needs nothing extra installed in the image (there is no curl in
+      # /health is the API's own readiness route: it pings Mongo and 503s if the
+      # database is unreachable, so `r.ok` turns this container unhealthy when
+      # Mongo dies rather than only when the process does. node 24 ships global
+      # fetch, so this needs nothing extra in the image (there is no curl in
       # node:24-slim). update.sh's `up --wait` blocks on this, which is what
-      # turns "container started" into "container actually serving".
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3001/hello').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      # turns "container started" into "container actually serving" — and now
+      # means a deploy attempted while Mongo is down fails rather than going
+      # green.
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3001/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,6 +209,9 @@ Three lines are worth reading carefully:
 - **`Container state: healthy`** means `--wait` actually blocked on the
   healthcheck. If it says `NO HEALTHCHECK`, this box's compose file is missing
   the healthcheck block and the deploy only confirmed the container is *running*.
+  The healthcheck probes `/health`, which pings Mongo — so `healthy` means the
+  database answered too, and a deploy attempted while Mongo is down will fail
+  here rather than going green.
 - **`Deployment finished!`** is the last line of a successful run. If the log ends
   anywhere else, the deploy died — and a `DEPLOY FAILED (exit N) at line L` line
   should say where:
@@ -223,8 +226,8 @@ container sf-backend is unhealthy
 Then confirm the API itself:
 
 ```bash
-curl -s https://api.satisfactory-factories.app/hello
-# {"message":"Hello, the server is running!"}
+curl -s https://api.satisfactory-factories.app/health
+# {"status":"ok","uptime":142,"database":{"status":"ok","state":"connected","responseTime":3}}
 
 ssh sf 'docker ps --format "{{.Names}}\t{{.Image}}\t{{.Status}}"'
 # sf-backend  maelstromeous/satisfactory-factories:backend-latest  Up 2 minutes (healthy)
@@ -282,6 +285,9 @@ On the box (`ssh sf`), one-off, and not done by any deploy:
 - `/root/docker/docker-compose.yml` must match `backend/docker-compose-server.yml`
   — the Docker Hub image and the healthcheck that `up --wait` blocks on. The
   existing `3001:3001` port line is already correct and needs no change.
+  **The healthcheck moved from `/hello` to `/health`** and the box's copy has to
+  be edited by hand for that to take effect; until it is, the container's health
+  state still only proves the process is up.
 - `/root/update.sh` must match `backend/update.sh`, mode `755`.
 - The webhooks box's deploy key must be in `/root/.ssh/authorized_keys`
   (fingerprint `SHA256:Y69lglv47Mp3dkMh9a/CL1u9PmYldx4u+NTDb0QiFDs`).


### PR DESCRIPTION
## Why

The API box filled its disk and took the database with it, and monitoring stayed green throughout. It was pointed at `GET /hello`, which is this in full:

```ts
res.status(200).json({ message: 'Hello, the server is running!' });
```

That returns `200` for as long as the Node process is alive. It never speaks to Mongo, so the database can be dead, unreachable or out of disk and the check still passes. There was no other health route to extend.

## What this adds

`GET /health` runs a real `ping` against Mongo — the `SELECT 1` equivalent — and returns **503** with the error message when it doesn't answer:

```json
{"status":"ok","uptime":142,"database":{"status":"ok","state":"connected","responseTime":1}}
```

The response carries process uptime, the Mongoose connection state and the ping's round trip, so `curl` answers "what broke" without opening logs.

**The 3s race is load-bearing.** Mongoose is configured with `bufferCommands`, so a command issued against a dead database doesn't fail — it queues for ten seconds. That is longer than the Docker healthcheck's timeout and longer than any monitor will wait, so without the race a dead database presents as a slow one.

**`readyState` alone would not have worked.** With the database container paused, `mongoose.connection.readyState` still reported `connected` while every command hung. Only an actual command catches that, which is why this pings rather than inspecting connection state.

**`/health` gets its own 10-a-minute limiter** and is exempt from the global one, so it sits in a single bucket and no amount of other traffic can push a monitor into a `429` and a false outage. The uptime service probes from three sources, each on its own IP bucket.

`/hello` is unchanged and stays as a pure liveness route.

## Behaviour change worth flagging

The production container's healthcheck now probes `/health` instead of `/hello`, so `docker ps` reports unhealthy when Mongo dies rather than only when the process does.

The consequence: **a deploy attempted while Mongo is down now fails at `up -d --wait` instead of going green.** That is intended, but it is the kind of thing that is surprising months later.

`docker-compose-server.yml` is a hand-maintained mirror — no deploy syncs it. Until the box's copy is edited by hand, its healthcheck still probes `/hello` and only proves the process is up. Noted in `docs/deployment.md` and in `.claude/memory/`.

## Validation

Run against a live Mongo, with the container paused (hung) and stopped (refused):

| Case | Result |
| --- | --- |
| Mongo up | `200`, ping 1ms |
| Mongo hung (`docker pause`) | `503` in 3.007s |
| Mongo stopped | `503`, `state: disconnected` |
| Mongo restarted | back to `200` with no API restart |
| Rate limit | 10 requests through, then `429`; `/hello` unaffected |
| Compose probe, run verbatim | exit `0` healthy, exit `1` while Mongo hung |

The recovery leg matters: the endpoint re-reports healthy on its own rather than latching failed until the API is restarted.

`tsc --noEmit` clean; `pnpm lint` reports 0 errors (3 pre-existing `no-explicit-any` warnings, untouched).

## Deliberately not included

- **No write probe.** The ping catches mongod dead, unreachable, auth broken or the connection dropped — including a full disk that took mongod down with it, which is the usual outcome. It will not catch a mongod that is up and cannot write. If that gap bites, the fix is an upsert into a `healthcheck` collection.
- **No disk-space check.** The API container's disk is not necessarily the one that fills. That belongs in host monitoring, not in the app.

## Follow-up needed after merge

Copy the healthcheck line into the box's compose file by hand and `docker compose up -d --wait backend`. Nothing in the deploy does this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)